### PR TITLE
Fix assets

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ http.createServer(function(req, res) {
 
     parse(project);
 
-    archive.append(body, { name: 'project.json' });
+    archive.append(JSON.stringify(project), { name: 'project.json' });
     archive.finalize(function() {
       res.end();
     });


### PR DESCRIPTION
As it turns out, 7e97d7d is a bad idea. Using Scratch's JSON is incorrect, because it doesn't refer to
the assets which we're including.